### PR TITLE
Remove old IPBC hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "cli-color": "*",
         "cryptoforknote-util": "git://github.com/MoneroOcean/node-cryptoforknote-util.git",
         "cryptonight-hashing": "git://github.com/MoneroOcean/node-cryptonight-hashing.git",
-        "multi-hashing": "git://github.com/muscleman/node-multi-hashing.git#ipbc",
         "dateformat": "*",
         "mailgun.js": "*",
         "node-telegram-bot-api": "*",


### PR DESCRIPTION
This repo and this algo do not exist anymore. It causes npm install error